### PR TITLE
Fixing the "middleware is not a function"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 var riot = require('riot')
 var redux = require('redux')
-var thunk = require('redux-thunk')
+var thunk = require('redux-thunk').default
 
 require('./tags/todo-app.tag')
 require('./tags/task-list.tag')


### PR DESCRIPTION
This error bit me every time I copy this awesome project. 

The fix is [simple enough though](https://github.com/gaearon/redux-thunk/issues/35)